### PR TITLE
feat: add MacWhisper model discovery (core functionality from #3)

### DIFF
--- a/SharedSources/WhisperModelManager.swift
+++ b/SharedSources/WhisperModelManager.swift
@@ -28,7 +28,7 @@ public class WhisperModelManager {
     
     private let fileManager = FileManager.default
     
-    /// Get the base path for WhisperKit models
+    /// Get the base path for WhisperKit models (app's own directory)
     public func getModelsBasePath() -> URL {
         let documentsPath = fileManager.urls(for: .documentDirectory, in: .userDomainMask).first!
         return documentsPath
@@ -37,10 +37,43 @@ public class WhisperModelManager {
             .appendingPathComponent("argmaxinc")
             .appendingPathComponent("whisperkit-coreml")
     }
-    
-    /// Get the path for a specific model
+
+    /// Get the base path for MacWhisper models (read-only, for reuse)
+    public func getMacWhisperBasePath() -> URL {
+        let homeDirectory = fileManager.homeDirectoryForCurrentUser
+        return homeDirectory
+            .appendingPathComponent("Library")
+            .appendingPathComponent("Application Support")
+            .appendingPathComponent("MacWhisper")
+            .appendingPathComponent("models")
+            .appendingPathComponent("whisperkit")
+            .appendingPathComponent("models")
+            .appendingPathComponent("argmaxinc")
+            .appendingPathComponent("whisperkit-coreml")
+    }
+
+    /// Check if a model exists in MacWhisper's directory
+    public func macWhisperModelExists(_ modelName: String) -> Bool {
+        let macWhisperPath = getMacWhisperBasePath().appendingPathComponent(modelName)
+        return isValidModelDirectory(at: macWhisperPath)
+    }
+
+    /// Get the path for a specific model (checks app directory first, then MacWhisper)
     public func getModelPath(for modelName: String) -> URL {
-        return getModelsBasePath().appendingPathComponent(modelName)
+        // Check app's own directory first (takes precedence)
+        let appPath = getModelsBasePath().appendingPathComponent(modelName)
+        if isValidModelDirectory(at: appPath) {
+            return appPath
+        }
+
+        // Fallback to MacWhisper if available
+        let macWhisperPath = getMacWhisperBasePath().appendingPathComponent(modelName)
+        if isValidModelDirectory(at: macWhisperPath) {
+            return macWhisperPath
+        }
+
+        // Default to app path (for new downloads)
+        return appPath
     }
     
     /// Get the metadata file path for a model
@@ -102,22 +135,42 @@ public class WhisperModelManager {
         return metadata
     }
     
-    /// Get all downloaded models
+    /// Get all downloaded models (from both app and MacWhisper directories)
     public func getDownloadedModels() -> [String] {
-        let modelsPath = getModelsBasePath()
-        
-        guard let modelDirs = try? fileManager.contentsOfDirectory(
-            at: modelsPath,
+        var modelNames = Set<String>()
+
+        // Check app's own directory
+        let appModelsPath = getModelsBasePath()
+        if let appModelDirs = try? fileManager.contentsOfDirectory(
+            at: appModelsPath,
             includingPropertiesForKeys: nil,
             options: [.skipsHiddenFiles]
-        ) else {
-            return []
+        ) {
+            for modelDir in appModelDirs {
+                let modelName = modelDir.lastPathComponent
+                if isModelDownloaded(modelName) || isValidModelDirectory(at: modelDir) {
+                    modelNames.insert(modelName)
+                }
+            }
         }
-        
-        return modelDirs.compactMap { modelDir in
-            let modelName = modelDir.lastPathComponent
-            return isModelDownloaded(modelName) ? modelName : nil
+
+        // Check MacWhisper directory
+        let macWhisperPath = getMacWhisperBasePath()
+        if fileManager.fileExists(atPath: macWhisperPath.path),
+           let macWhisperDirs = try? fileManager.contentsOfDirectory(
+            at: macWhisperPath,
+            includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles]
+        ) {
+            for modelDir in macWhisperDirs {
+                let modelName = modelDir.lastPathComponent
+                if isValidModelDirectory(at: modelDir) {
+                    modelNames.insert(modelName)
+                }
+            }
         }
+
+        return Array(modelNames).sorted()
     }
     
     /// Check if a model exists on disk (regardless of download status)
@@ -185,7 +238,30 @@ public class WhisperModelManager {
     }
     
     // MARK: - Helper Methods
-    
+
+    /// Validates that a directory contains required WhisperKit model components
+    private func isValidModelDirectory(at path: URL) -> Bool {
+        guard fileManager.fileExists(atPath: path.path) else {
+            return false
+        }
+
+        // Check for essential WhisperKit model files
+        let requiredComponents = [
+            "AudioEncoder.mlmodelc",
+            "MelSpectrogram.mlmodelc",
+            "TextDecoder.mlmodelc",
+            "config.json"
+        ]
+
+        for component in requiredComponents {
+            let componentPath = path.appendingPathComponent(component)
+            if !fileManager.fileExists(atPath: componentPath.path) {
+                return false
+            }
+        }
+        return true
+    }
+
     private func countFiles(in directory: URL) -> Int {
         guard let enumerator = fileManager.enumerator(
             at: directory,


### PR DESCRIPTION
## Summary

This PR extracts the **core model discovery functionality** from #3 to enable reusing WhisperKit models already downloaded by the MacWhisper app.

**What's included:**
- `getMacWhisperBasePath()` - Path to MacWhisper's model directory
- `macWhisperModelExists()` - Check if model exists in MacWhisper
- `isValidModelDirectory()` - Validate WhisperKit model components
- Updated `getModelPath()` - Checks app dir first, falls back to MacWhisper
- Updated `getDownloadedModels()` - Scans both directories with deduplication

**What's NOT included (left for follow-up PR):**
- `ModelSource.swift` enum
- `getModelSource()` method
- UI badges showing model origin
- Color-coded icons and tooltips

## Context

This addresses the iCloud sync concern raised in #3 for users who already have MacWhisper installed - they can now reuse existing models (~1.54 GB for Large v3) without downloading duplicates.

## How it works

1. App checks its own directory first (`~/Documents/huggingface/...`)
2. If not found, checks MacWhisper's directory (`~/Library/Application Support/MacWhisper/...`)
3. MacWhisper models are read-only (never modified by this app)

## Testing

- Build: `swift build`
- Users with MacWhisper installed should see their models available automatically