### PR TITLE
feat: add os_log logging for Console.app diagnostics

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,3 +57,24 @@
 - **Cmd+Opt+A**: Show transcription history
 - **Cmd+Opt+V**: Paste last transcription at cursor
 
+## Logging
+
+Uses `os.log` (`Logger`) with subsystem `com.supervoiceassistant` so errors are always visible in Console.app regardless of how the app is launched.
+
+**Categories**:
+- `App` (`main.swift`) - startup, env loading, TTS errors, recording failures, transcription errors
+- `AudioCollector` (`GeminiAudioCollector.swift`) - Gemini API errors (code/status/message), JSON parse errors, WebSocket connection failures
+- `StreamingPlayer` (`GeminiStreamingPlayer.swift`) - playback errors, retry attempts
+
+**Querying logs**:
+```bash
+# All app logs from last hour
+log show --predicate 'subsystem == "com.supervoiceassistant"' --last 1h --style compact
+
+# Errors only
+log show --predicate 'subsystem == "com.supervoiceassistant" AND messageType == 16' --last 1h
+
+# Specific category
+log show --predicate 'subsystem == "com.supervoiceassistant" AND category == "AudioCollector"' --last 1h
+```
+

--- a/SharedSources/GeminiAudioCollector.swift
+++ b/SharedSources/GeminiAudioCollector.swift
@@ -1,4 +1,7 @@
 import Foundation
+import os.log
+
+private let audioCollectorLog = Logger(subsystem: "com.supervoiceassistant", category: "AudioCollector")
 
 @available(macOS 14.0, *)
 public class GeminiAudioCollector {
@@ -117,6 +120,7 @@ public class GeminiAudioCollector {
                             let message = error["message"] as? String ?? "Unknown error"
                             let status = error["status"] as? String ?? ""
                             print("🚨 API Error - Code: \(code), Status: \(status), Message: \(message)")
+                            audioCollectorLog.error("API Error - Code: \(code), Status: \(status, privacy: .public), Message: \(message, privacy: .public)")
                         }
                     }
 
@@ -133,6 +137,7 @@ public class GeminiAudioCollector {
                                 let message = error["message"] as? String ?? "Unknown error"
                                 let status = error["status"] as? String ?? ""
                                 print("🚨 API Error - Code: \(code), Status: \(status), Message: \(message)")
+                                audioCollectorLog.error("API Error (data) - Code: \(code), Status: \(status, privacy: .public), Message: \(message, privacy: .public)")
                             }
 
                             // Check for completion in JSON response
@@ -162,6 +167,7 @@ public class GeminiAudioCollector {
                         }
                     } catch {
                         print("⚠️ JSON parsing error: \(error)")
+                        audioCollectorLog.warning("JSON parsing error: \(error.localizedDescription, privacy: .public)")
                     }
                 @unknown default:
                     break
@@ -175,6 +181,7 @@ public class GeminiAudioCollector {
             
         } catch {
             // Close connection on error to prevent resource leaks
+            audioCollectorLog.error("Audio collection failed: \(error.localizedDescription, privacy: .public)")
             closeConnection()
             throw GeminiAudioCollectorError.collectionError(error)
         }

--- a/SharedSources/GeminiStreamingPlayer.swift
+++ b/SharedSources/GeminiStreamingPlayer.swift
@@ -1,5 +1,8 @@
 import Foundation
 import AVFoundation
+import os.log
+
+private let streamingPlayerLog = Logger(subsystem: "com.supervoiceassistant", category: "StreamingPlayer")
 
 @available(macOS 14.0, *)
 public class GeminiStreamingPlayer {
@@ -111,6 +114,7 @@ public class GeminiStreamingPlayer {
             reset()
 
         } catch {
+            streamingPlayerLog.error("Playback stream error: \(error.localizedDescription, privacy: .public)")
             reset()  // Clean up on error too
             throw GeminiStreamingPlayerError.playbackError(error)
         }
@@ -143,6 +147,7 @@ public class GeminiStreamingPlayer {
 
                 if isNetworkError && attempt < maxRetries {
                     print("⚠️ TTS attempt \(attempt) failed, retrying in 1s... Error: \(error.localizedDescription)")
+                    streamingPlayerLog.warning("TTS attempt \(attempt) failed, retrying: \(error.localizedDescription, privacy: .public)")
                     try await Task.sleep(nanoseconds: 1_000_000_000) // 1 second delay
                     reset() // Reset player state before retry
                 } else {


### PR DESCRIPTION
## Summary
- Adds `os.log` (`Logger`) with subsystem `com.supervoiceassistant` so errors are always visible in Console.app, regardless of how the app is launched
- Covers TTS errors, Gemini API errors, recording failures, and transcription errors across 3 categories: `App`, `AudioCollector`, `StreamingPlayer`
- Updates CLAUDE.md with logging documentation and `log show` query examples

## Test plan
- [x] Build succeeds with `swift build`
- [ ] Trigger a TTS error (e.g. invalid API key) and verify it appears in Console.app via `log show --predicate 'subsystem == "com.supervoiceassistant"' --last 5m`
- [ ] Verify normal TTS playback still works without regressions