### PR TITLE
Fix Swift 6.3 build break: upgrade FluidAudio, WhisperKit, swift-transformers

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,21 +1,21 @@
 {
   "pins" : [
     {
+      "identity" : "eventsource",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattt/EventSource.git",
+      "state" : {
+        "revision" : "a3a85a85214caf642abaa96ae664e4c772a59f6e",
+        "version" : "1.4.1"
+      }
+    },
+    {
       "identity" : "fluidaudio",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/FluidInference/FluidAudio.git",
       "state" : {
-        "revision" : "0afbabca218c6c0e363fc128e1b50be4e69abc5e",
-        "version" : "0.10.1"
-      }
-    },
-    {
-      "identity" : "jinja",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/johnmai-dev/Jinja",
-      "state" : {
-        "revision" : "bb238dd96fbe4c18014f3107c00edd6edb15428e",
-        "version" : "1.2.4"
+        "revision" : "aa800cb9630dc14727507ac0c955fa4d7ca415ec",
+        "version" : "0.12.6"
       }
     },
     {
@@ -32,8 +32,26 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser.git",
       "state" : {
-        "revision" : "309a47b2b1d9b5e991f36961c983ecec72275be3",
-        "version" : "1.6.1"
+        "revision" : "ca37474853a4b5f59a22c74bfdd449b1f6bc4cc2",
+        "version" : "1.8.1"
+      }
+    },
+    {
+      "identity" : "swift-asn1",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-asn1.git",
+      "state" : {
+        "revision" : "eb50cbd14606a9161cbc5d452f18797c90ef0bab",
+        "version" : "1.7.0"
+      }
+    },
+    {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
+        "version" : "1.3.0"
       }
     },
     {
@@ -46,12 +64,57 @@
       }
     },
     {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "1b6b2e274e85105bfa155183145a1dcfd63331f1",
+        "version" : "4.5.0"
+      }
+    },
+    {
+      "identity" : "swift-huggingface",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/huggingface/swift-huggingface.git",
+      "state" : {
+        "revision" : "b721959445b617d0bf03910b2b4aced345fd93bf",
+        "version" : "0.9.0"
+      }
+    },
+    {
+      "identity" : "swift-jinja",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/huggingface/swift-jinja.git",
+      "state" : {
+        "revision" : "0b67ecb79139f6addef8699eff3622808aa6c7dc",
+        "version" : "2.3.6"
+      }
+    },
+    {
+      "identity" : "swift-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio.git",
+      "state" : {
+        "revision" : "57c0a08a331aaea9f5d7a932ad94ef43be942a95",
+        "version" : "2.100.0"
+      }
+    },
+    {
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system.git",
+      "state" : {
+        "revision" : "7c6ad0fc39d0763e0b699210e4124afd5041c5df",
+        "version" : "1.6.4"
+      }
+    },
+    {
       "identity" : "swift-transformers",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/huggingface/swift-transformers.git",
       "state" : {
-        "revision" : "8a83416cc00ab07a5de9991e6ad817a9b8588d20",
-        "version" : "0.1.15"
+        "revision" : "2fa33e1f5e7131a7fc64c28e6d161dcec0d24820",
+        "version" : "1.3.3"
       }
     },
     {
@@ -59,8 +122,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/argmaxinc/WhisperKit",
       "state" : {
-        "revision" : "c814caea8876036f0c87a0de29552f028d59832d",
-        "version" : "0.13.1"
+        "revision" : "25c62997041c134b03ca82731ce2f6fd2cae1eb9",
+        "version" : "1.0.0"
+      }
+    },
+    {
+      "identity" : "yyjson",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ibireme/yyjson.git",
+      "state" : {
+        "revision" : "8b4a38dc994a110abaec8a400615567bd996105f",
+        "version" : "0.12.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -54,8 +54,11 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/sindresorhus/KeyboardShortcuts", exact: "1.8.0"),
-        .package(url: "https://github.com/argmaxinc/WhisperKit", from: "0.13.0"),
-        .package(url: "https://github.com/FluidInference/FluidAudio.git", from: "0.7.9")
+        .package(url: "https://github.com/argmaxinc/WhisperKit", from: "1.0.0"),
+        // Pinned to 0.12.x: 0.12.6 converts AsrManager to an actor (fixes Swift 6.3
+        // `sending` data-race errors), while 0.13.0+ changes the transcribe() API to
+        // require an inout TdtDecoderState, which would break ParakeetTranscriber.
+        .package(url: "https://github.com/FluidInference/FluidAudio.git", .upToNextMinor(from: "0.12.6"))
     ],
     targets: [
         .target(

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,41 @@
+# Roadmap & Known Constraints
+
+## Dependency Pinning
+
+### FluidAudio is pinned to 0.12.x (`.upToNextMinor(from: "0.12.6")`)
+
+Do **not** loosen this to `from:` or bump to 0.13+ without a code change.
+
+- **Why 0.12.6 (floor):** Swift 6.3 (Xcode 26) makes the region-based `sending`
+  data-race check a hard error. FluidAudio ≤0.10.x (built in Swift 6 language mode)
+  fails to compile because `StreamingAsrManager` (an actor) sends a self-isolated
+  `AsrManager` *class* into nonisolated async calls. FluidAudio 0.12.6 fixes this by
+  converting `AsrManager` to an `actor` (upstream PR #419).
+- **Why not 0.13+ (ceiling):** 0.13.0 changed the `transcribe()` API to require an
+  `inout TdtDecoderState` and removed the simple `transcribe(_ audioSamples:)`
+  convenience overload that `SharedSources/ParakeetTranscriber.swift` relies on.
+  Moving past 0.12.x means rewriting the Parakeet transcription path to create and
+  manage decoder state.
+
+### Coupled upgrade: WhisperKit 1.0.0 + swift-transformers 1.3.3
+
+FluidAudio 0.12.6 requires `swift-transformers ≥ 1.2.0`, which the old WhisperKit
+(0.13.1, on swift-transformers 0.1.x) capped below. They must move together:
+
+- WhisperKit `0.13.1` → `1.0.0`
+- swift-transformers `0.1.15` → `1.3.3`
+
+WhisperKit 1.0.0 API changes that were applied:
+- `DecodingOptions` removed `usePrefillCache`.
+- `DecodingOptions` renamed `supressTokens` → `suppressTokens` (fixed the old typo).
+
+## To verify
+
+- [x] Runtime smoke test of WhisperKit transcription (Cmd+Opt+Z) after the major
+      WhisperKit 0.13.1 → 1.0.0 bump. — passed initial smoke test.
+- [x] Runtime smoke test of Parakeet transcription (FluidAudio 0.12.6 actor change +
+      `ParakeetTranscriber.isReady` now derived from local `loadingState`). — passed
+      initial smoke test.
+
+> Note: these were quick happy-path smoke tests. A longer real-world soak is still
+> recommended given the major WhisperKit / swift-transformers version jumps.

--- a/SharedSources/ParakeetTranscriber.swift
+++ b/SharedSources/ParakeetTranscriber.swift
@@ -180,8 +180,12 @@ public class ParakeetTranscriber {
     }
 
     /// Check if a model is loaded and ready
+    ///
+    /// `loadingState` is only set to `.loaded` after `AsrManager.initialize` succeeds,
+    /// so it tracks readiness without touching the now actor-isolated `isAvailable`
+    /// (which can't be read synchronously here).
     public var isReady: Bool {
-        return asrManager?.isAvailable ?? false && loadingState == .loaded
+        return asrManager != nil && loadingState == .loaded
     }
 
     /// Unload the current model to free memory

--- a/Sources/AudioTranscriptionManager.swift
+++ b/Sources/AudioTranscriptionManager.swift
@@ -324,12 +324,11 @@ class AudioTranscriptionManager {
                     sampleLength: 224,
                     topK: 5,
                     usePrefillPrompt: true,
-                    usePrefillCache: true,
                     skipSpecialTokens: true,
                     withoutTimestamps: true,
                     clipTimestamps: [],
                     suppressBlank: true,
-                    supressTokens: nil
+                    suppressTokens: nil
                 )
             )
 

--- a/tests/test-live-transcription/main.swift
+++ b/tests/test-live-transcription/main.swift
@@ -139,12 +139,11 @@ class LiveTranscriptionTest {
                 sampleLength: 224,
                 topK: 5,
                 usePrefillPrompt: true,
-                usePrefillCache: true,
                 skipSpecialTokens: true,
                 withoutTimestamps: false,
                 clipTimestamps: [0],
                 suppressBlank: true,
-                supressTokens: nil
+                suppressTokens: nil
             )
         )
         

--- a/tests/test-transcription/main.swift
+++ b/tests/test-transcription/main.swift
@@ -141,12 +141,11 @@ struct TranscriptionTester {
                     sampleLength: 224,
                     topK: 5,
                     usePrefillPrompt: true,
-                    usePrefillCache: true,
                     skipSpecialTokens: true,
                     withoutTimestamps: false,
                     clipTimestamps: [0],
                     suppressBlank: true,
-                    supressTokens: nil
+                    suppressTokens: nil
                 )
             )
             


### PR DESCRIPTION
## ⚠️ Please review carefully — Claude did the heavy lifting

Most of this change (dependency-conflict analysis, version selection, and the API
migration) was done by **Claude (Anthropic's Claude Code)**. It builds cleanly and
passed quick happy-path smoke tests, but it involves **major dependency bumps** and
**genuinely needs a careful human review** before merging.

## Problem

Swift 6.3 (Xcode 26) promotes the region-based `sending` data-race check to a hard
error in Swift 6 language mode. **FluidAudio 0.10.1 no longer compiles** —
`StreamingAsrManager` (an actor) sends a self-isolated `AsrManager` *class* into
nonisolated async calls:

```
StreamingAsrManager.swift:319:77: error: sending 'asrManager' risks causing data races [#SendingRisksDataRace]
```

## Fix

Upstream fixed this in **FluidAudio 0.12.6** by converting `AsrManager` to an `actor`.
That version requires `swift-transformers >= 1.2.0`, which the old WhisperKit capped
below — so all three must move together:

| Dependency | From | To |
|---|---|---|
| FluidAudio | 0.10.1 | **0.12.6** (pinned `.upToNextMinor`) |
| WhisperKit | 0.13.1 | **1.0.0** |
| swift-transformers | 0.1.15 | **1.3.3** |

FluidAudio is intentionally pinned to **0.12.x**: 0.13+ changes the `transcribe()`
API to require an `inout TdtDecoderState` and drops the simple `transcribe(_:)`
overload this app uses. See `ROADMAP.md` (added here) for the full rationale.

### Source changes for the new APIs
- **`ParakeetTranscriber.isReady`** — `AsrManager` is now an `actor`, so `isAvailable`
  can't be read synchronously; readiness is derived from local `loadingState` (set
  only after a successful `initialize`).
- **`DecodingOptions` (WhisperKit 1.0.0)** — removed `usePrefillCache`; renamed
  `supressTokens` → `suppressTokens`. Applied to the main app and two test helpers.

## What reviewers should scrutinize
- The **major WhisperKit (0.13.1 → 1.0.0)** and **swift-transformers (0.1.x → 1.3.3)**
  jumps — only happy-path smoke tested so far; subtler behavior (accuracy, language
  detection, timestamps) deserves a real-world soak.
- `isReady` is now local-state-derived rather than asking FluidAudio directly —
  believed equivalent for this flow, but worth a second look.
- ~8 new transitive deps (swift-nio, Crypto, ArgmaxCore, etc.) come in via the bump.

## Testing
- ✅ `swift build` clean
- ✅ Quick happy-path smoke test of WhisperKit (Cmd+Opt+Z) and Parakeet transcription
- ⬜ Longer real-world soak — recommended before merge