### PR TITLE
Keep Parakeet model warm to avoid page-out latency

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,10 @@ cd super-voice-assistant
 # Install ffmpeg (required for screen recording)
 brew install ffmpeg
 
-# Set up environment (for TTS and video transcription)
+# Set up your Gemini API key (for TTS and video transcription)
+# Option 1: macOS keychain (recommended)
+security add-generic-password -U -s gemini-api-key -a "$USER" -w YOUR_KEY
+# Option 2: .env file
 cp .env.example .env
 # Edit .env and add your GEMINI_API_KEY
 
@@ -128,7 +131,7 @@ This is useful for correcting common speech-to-text misrecognitions, especially 
 6. Press **Escape** to cancel
 
 **Cloud (Cmd+Option+X):**
-1. Set GEMINI_API_KEY in your .env file
+1. Set your Gemini API key (keychain or .env file, see Installation)
 2. Press **Command+Option+X** to start/stop recording
 3. Text automatically pastes at cursor
 

--- a/SharedSources/GeminiAPIKey.swift
+++ b/SharedSources/GeminiAPIKey.swift
@@ -1,0 +1,52 @@
+import Foundation
+import Security
+
+/// Resolves the Gemini API key from (in order):
+/// 1. GEMINI_API_KEY environment variable
+/// 2. macOS keychain generic password with service "gemini-api-key"
+///    (store it with: security add-generic-password -U -s gemini-api-key -a "$USER" -w YOUR_KEY)
+/// 3. .env file in the current working directory
+public enum GeminiAPIKey {
+    public static func resolve() -> String? {
+        if let envKey = ProcessInfo.processInfo.environment["GEMINI_API_KEY"], !envKey.isEmpty {
+            return envKey
+        }
+        if let keychainKey = fromKeychain() {
+            return keychainKey
+        }
+        return fromEnvFile()
+    }
+
+    private static func fromKeychain() -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: "gemini-api-key",
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        guard status == errSecSuccess,
+              let data = result as? Data,
+              let key = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !key.isEmpty else {
+            return nil
+        }
+        return key
+    }
+
+    private static func fromEnvFile() -> String? {
+        guard let envContent = try? String(contentsOfFile: ".env", encoding: .utf8) else {
+            return nil
+        }
+        for line in envContent.components(separatedBy: .newlines) {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if trimmed.hasPrefix("GEMINI_API_KEY=") {
+                let key = String(trimmed.dropFirst("GEMINI_API_KEY=".count))
+                return key.isEmpty ? nil : key
+            }
+        }
+        return nil
+    }
+}

--- a/SharedSources/GeminiAudioTranscriber.swift
+++ b/SharedSources/GeminiAudioTranscriber.swift
@@ -16,7 +16,7 @@ public class GeminiAudioTranscriber {
         public var errorDescription: String? {
             switch self {
             case .apiKeyNotFound:
-                return "GEMINI_API_KEY not found in environment or .env file"
+                return "GEMINI_API_KEY not found in environment, keychain, or .env file"
             case .audioConversionFailed:
                 return "Failed to convert audio to WAV format"
             case .requestFailed(let statusCode, let message):
@@ -162,26 +162,7 @@ public class GeminiAudioTranscriber {
     // MARK: - Private Helpers
 
     private func loadApiKey() -> String? {
-        // Check environment variable first
-        if let envKey = ProcessInfo.processInfo.environment["GEMINI_API_KEY"] {
-            return envKey
-        }
-
-        // Try to read from .env file
-        let envPath = ".env"
-        guard let envContent = try? String(contentsOfFile: envPath, encoding: .utf8) else {
-            return nil
-        }
-
-        for line in envContent.components(separatedBy: .newlines) {
-            let trimmed = line.trimmingCharacters(in: .whitespaces)
-            if trimmed.hasPrefix("GEMINI_API_KEY=") {
-                let key = String(trimmed.dropFirst("GEMINI_API_KEY=".count))
-                return key.isEmpty ? nil : key
-            }
-        }
-
-        return nil
+        return GeminiAPIKey.resolve()
     }
 
     /// Convert Float audio buffer to WAV format Data

--- a/SharedSources/VideoTranscriber.swift
+++ b/SharedSources/VideoTranscriber.swift
@@ -16,7 +16,7 @@ public class VideoTranscriber {
         public var errorDescription: String? {
             switch self {
             case .apiKeyNotFound:
-                return "GEMINI_API_KEY not found in environment or .env file"
+                return "GEMINI_API_KEY not found in environment, keychain, or .env file"
             case .fileNotFound:
                 return "Video file not found"
             case .readFailed:
@@ -161,26 +161,7 @@ public class VideoTranscriber {
     // MARK: - Private Helpers
 
     private func loadApiKey() -> String? {
-        // Check environment variable first
-        if let envKey = ProcessInfo.processInfo.environment["GEMINI_API_KEY"] {
-            return envKey
-        }
-
-        // Try to read from .env file
-        let envPath = ".env"
-        guard let envContent = try? String(contentsOfFile: envPath, encoding: .utf8) else {
-            return nil
-        }
-
-        for line in envContent.components(separatedBy: .newlines) {
-            let trimmed = line.trimmingCharacters(in: .whitespaces)
-            if trimmed.hasPrefix("GEMINI_API_KEY=") {
-                let key = String(trimmed.dropFirst("GEMINI_API_KEY=".count))
-                return key.isEmpty ? nil : key
-            }
-        }
-
-        return nil
+        return GeminiAPIKey.resolve()
     }
 
     private func getMimeType(for fileExtension: String) -> String {

--- a/Sources/AudioTranscriptionManager.swift
+++ b/Sources/AudioTranscriptionManager.swift
@@ -379,6 +379,9 @@ class AudioTranscriptionManager {
         print("Transcribing \(audioBuffer.count) samples (\(Double(audioBuffer.count) / sampleRate) seconds) with Parakeet...")
         MemoryMonitor.shared.checkpoint("before Parakeet transcribe")
 
+        ModelStateManager.shared.isParakeetTranscribing = true
+        defer { ModelStateManager.shared.isParakeetTranscribing = false }
+
         do {
             let transcription = try await transcriber.transcribe(audioSamples: paddedBuffer)
             MemoryMonitor.shared.checkpoint("after Parakeet transcribe")

--- a/Sources/ModelStateManager.swift
+++ b/Sources/ModelStateManager.swift
@@ -56,6 +56,20 @@ class ModelStateManager: ObservableObject {
     }
     @Published var parakeetLoadingState: ParakeetLoadingState = .notDownloaded
     private var currentParakeetLoadingTask: Task<Void, Never>? = nil
+    private var parakeetKeepWarmTask: Task<Void, Never>? = nil
+    var isParakeetTranscribing = false
+    @Published var parakeetKeepWarmEnabled: Bool = true {
+        didSet {
+            UserDefaults.standard.set(parakeetKeepWarmEnabled, forKey: "parakeetKeepWarmEnabled")
+            if parakeetKeepWarmEnabled {
+                if parakeetLoadingState == .loaded {
+                    startParakeetKeepWarm()
+                }
+            } else {
+                stopParakeetKeepWarm()
+            }
+        }
+    }
 
     // MARK: - WhisperKit State
     @Published var downloadedModels: Set<String> = []
@@ -89,6 +103,11 @@ class ModelStateManager: ObservableObject {
 
         // Restore the selected WhisperKit model from UserDefaults
         self.selectedModel = UserDefaults.standard.string(forKey: "selectedWhisperModel")
+
+        // Restore the keep-warm preference from UserDefaults (default: enabled)
+        if UserDefaults.standard.object(forKey: "parakeetKeepWarmEnabled") != nil {
+            self.parakeetKeepWarmEnabled = UserDefaults.standard.bool(forKey: "parakeetKeepWarmEnabled")
+        }
     }
     
     func checkDownloadedModels() async {
@@ -368,6 +387,7 @@ class ModelStateManager: ObservableObject {
                 await MainActor.run {
                     self.loadedParakeetTranscriber = transcriber
                     self.parakeetLoadingState = .loaded
+                    self.startParakeetKeepWarm()
                 }
 
                 MemoryMonitor.shared.checkpoint("after Parakeet load: \(parakeetVersion.displayName)")
@@ -391,8 +411,38 @@ class ModelStateManager: ObservableObject {
         await task.value
     }
 
+    // MARK: - Parakeet Keep-Warm
+
+    /// Periodically run a tiny silent transcription so the model weights stay
+    /// "recently used" and macOS doesn't page them out to swap between real
+    /// transcriptions (page-in of ~1.4GB was adding seconds of latency on 8GB machines).
+    private func startParakeetKeepWarm() {
+        guard parakeetKeepWarmEnabled else { return }
+        parakeetKeepWarmTask?.cancel()
+        parakeetKeepWarmTask = Task { [weak self] in
+            let silence = [Float](repeating: 0.0, count: 32000)  // 2s at 16kHz
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: 60_000_000_000)
+                guard let self, !Task.isCancelled else { return }
+                guard self.parakeetKeepWarmEnabled,
+                      self.selectedEngine == .parakeet,
+                      !self.isParakeetTranscribing,
+                      let transcriber = self.loadedParakeetTranscriber,
+                      transcriber.isReady else { continue }
+                _ = try? await transcriber.transcribe(audioSamples: silence)
+                MemoryMonitor.shared.checkpoint("parakeet keep-warm ping")
+            }
+        }
+    }
+
+    private func stopParakeetKeepWarm() {
+        parakeetKeepWarmTask?.cancel()
+        parakeetKeepWarmTask = nil
+    }
+
     /// Unload Parakeet model to free memory
     func unloadParakeetModel() {
+        stopParakeetKeepWarm()
         loadedParakeetTranscriber?.unloadModel()
         loadedParakeetTranscriber = nil
 

--- a/Sources/ModelStateManager.swift
+++ b/Sources/ModelStateManager.swift
@@ -58,18 +58,8 @@ class ModelStateManager: ObservableObject {
     private var currentParakeetLoadingTask: Task<Void, Never>? = nil
     private var parakeetKeepWarmTask: Task<Void, Never>? = nil
     var isParakeetTranscribing = false
-    @Published var parakeetKeepWarmEnabled: Bool = true {
-        didSet {
-            UserDefaults.standard.set(parakeetKeepWarmEnabled, forKey: "parakeetKeepWarmEnabled")
-            if parakeetKeepWarmEnabled {
-                if parakeetLoadingState == .loaded {
-                    startParakeetKeepWarm()
-                }
-            } else {
-                stopParakeetKeepWarm()
-            }
-        }
-    }
+    /// Development flag: launch with `--no-keep-warm` to disable the keep-warm loop
+    let parakeetKeepWarmEnabled = !CommandLine.arguments.contains("--no-keep-warm")
 
     // MARK: - WhisperKit State
     @Published var downloadedModels: Set<String> = []
@@ -103,11 +93,6 @@ class ModelStateManager: ObservableObject {
 
         // Restore the selected WhisperKit model from UserDefaults
         self.selectedModel = UserDefaults.standard.string(forKey: "selectedWhisperModel")
-
-        // Restore the keep-warm preference from UserDefaults (default: enabled)
-        if UserDefaults.standard.object(forKey: "parakeetKeepWarmEnabled") != nil {
-            self.parakeetKeepWarmEnabled = UserDefaults.standard.bool(forKey: "parakeetKeepWarmEnabled")
-        }
     }
     
     func checkDownloadedModels() async {

--- a/Sources/SettingsWindow.swift
+++ b/Sources/SettingsWindow.swift
@@ -46,19 +46,6 @@ struct SettingsView: View {
                     }
                     .padding(.horizontal, 4)
 
-                    // Keep model warm so macOS doesn't page it out between transcriptions
-                    Toggle(isOn: $modelState.parakeetKeepWarmEnabled) {
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text("Keep model warm")
-                                .font(.subheadline)
-                            Text("Faster transcription; holds ~1.5 GB of memory while idle")
-                                .font(.caption)
-                                .foregroundColor(.secondary)
-                        }
-                    }
-                    .toggleStyle(.switch)
-                    .padding(.horizontal, 4)
-
                     // Parakeet models
                     ForEach(ParakeetVersion.allCases, id: \.self) { version in
                         ParakeetModelCard(

--- a/Sources/SettingsWindow.swift
+++ b/Sources/SettingsWindow.swift
@@ -46,6 +46,19 @@ struct SettingsView: View {
                     }
                     .padding(.horizontal, 4)
 
+                    // Keep model warm so macOS doesn't page it out between transcriptions
+                    Toggle(isOn: $modelState.parakeetKeepWarmEnabled) {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Keep model warm")
+                                .font(.subheadline)
+                            Text("Faster transcription; holds ~1.5 GB of memory while idle")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+                    }
+                    .toggleStyle(.switch)
+                    .padding(.horizontal, 4)
+
                     // Parakeet models
                     ForEach(ParakeetVersion.allCases, id: \.self) { version in
                         ParakeetModelCard(

--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -70,7 +70,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, AudioTranscriptionManagerDel
         loadEnvironmentVariables()
         
         // Initialize streaming TTS components if API key is available
-        if let apiKey = ProcessInfo.processInfo.environment["GEMINI_API_KEY"], !apiKey.isEmpty {
+        // (env var, macOS keychain, or .env file - see GeminiAPIKey)
+        if let apiKey = GeminiAPIKey.resolve() {
             if #available(macOS 14.0, *) {
                 streamingPlayer = GeminiStreamingPlayer(playbackSpeed: 1.15)
                 audioCollector = GeminiAudioCollector(apiKey: apiKey)
@@ -79,7 +80,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, AudioTranscriptionManagerDel
                 print("⚠️ Streaming TTS requires macOS 14.0 or later")
             }
         } else {
-            print("⚠️ GEMINI_API_KEY not found in environment variables")
+            print("⚠️ GEMINI_API_KEY not found in environment, keychain, or .env file")
         }
         
         // Create the status bar item


### PR DESCRIPTION
## Problem

On memory-constrained machines (e.g. 8 GB), macOS pages the ~1.4 GB of Parakeet model weights out to swap while the app sits idle between dictations. Every transcription then stalls for 2–6 seconds while the weights page back in — the Neural Engine inference itself is only a few hundred ms. `memory.log` showed the app collapsing to ~50 MB resident between transcriptions and re-inflating to ~1.5 GB on each one.

## Fix

- `ModelStateManager`: a keep-warm loop transcribes 2s of silence every 60s so the model weights stay recently-used and resident. Starts on model load, follows model version switches, stops on unload.
- `AudioTranscriptionManager`: sets a busy flag around real transcriptions so a keep-warm ping never overlaps one.
- Development flag: launch with `--no-keep-warm` (e.g. `swift run SuperVoiceAssistant --no-keep-warm`) to disable the loop for testing/comparison. No user-facing setting.

## Results

Measured via `memory.log` on an M3 MacBook Air / 8 GB: hotkey-to-text went from 2–6 s to ≤1 s; app memory stays resident between dictations. System stayed healthy (no pressure warnings) with the model held warm.

## Also in this PR: macOS keychain support for the Gemini API key

New shared `GeminiAPIKey` helper resolves the key in order: `GEMINI_API_KEY` env var → macOS keychain (generic password, service `gemini-api-key`) → `.env` file. Used by TTS init, Gemini audio transcription, and video transcription, replacing their duplicated env/.env lookups.

Store the key with:

```bash
security add-generic-password -U -s gemini-api-key -a "$USER" -w YOUR_KEY
```

This matches the key setup used by the claude-voice plugin, so one keychain entry serves both.
